### PR TITLE
Changed polling mode. Improved JMH. Improved System.loadLibrary.

### DIFF
--- a/jmh/qat-java-bench/pom.xml
+++ b/jmh/qat-java-bench/pom.xml
@@ -96,6 +96,35 @@ THE POSSIBILITY OF SUCH DAMAGE.
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.28.0</version>
+                <executions>
+                    <execution>
+                        <id>format</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <formats>
+                        <format>
+                            <includes>
+                              <include>*.java</include>
+                            </includes>
+                        </format>
+                    </formats>
+                    <java>
+                        <googleJavaFormat>
+                          <version>1.15.0</version>
+                        </googleJavaFormat>
+                    </java>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.1</version>

--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/BenchmarkDriver.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/BenchmarkDriver.java
@@ -63,7 +63,7 @@ public class BenchmarkDriver {
       Result r = rr.getAggregatedResult().getPrimaryResult();
       double speed = r.getScore() * fileSize / (1024 * 1024);
       System.out.printf(
-          "%s\t%.2f MB/sec\n", rr.getParams().getBenchmark(), speed);
+          "%-50s%.2f MB/sec\n", rr.getParams().getBenchmark(), speed);
     }
   }
 }

--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/BenchmarkDriver.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/BenchmarkDriver.java
@@ -42,16 +42,16 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 public class BenchmarkDriver {
   public static void main(String[] args) throws RunnerException {
-    if (args.length < 2)
-      throw new IllegalArgumentException("Input file required.");
+    if (args.length < 2) throw new IllegalArgumentException("Input file required.");
 
-    Options opts = new OptionsBuilder()
-                       .include(QatJavaBench.class.getSimpleName())
-                       .include(JavaZipBench.class.getSimpleName())
-                       .forks(1)
-                       .param("fileName", args[1])
-                       .jvmArgs("-Xms4g", "-Xmx4g")
-                       .build();
+    Options opts =
+        new OptionsBuilder()
+            .include(QatJavaBench.class.getSimpleName())
+            .include(JavaZipBench.class.getSimpleName())
+            .forks(1)
+            .param("fileName", args[1])
+            .jvmArgs("-Xms4g", "-Xmx4g")
+            .build();
 
     Collection<RunResult> results = new Runner(opts).run();
     System.out.println("-------------------------");
@@ -62,8 +62,7 @@ public class BenchmarkDriver {
     for (RunResult rr : results) {
       Result r = rr.getAggregatedResult().getPrimaryResult();
       double speed = r.getScore() * fileSize / (1024 * 1024);
-      System.out.printf(
-          "%-50s%.2f MB/sec\n", rr.getParams().getBenchmark(), speed);
+      System.out.printf("%-50s%.2f MB/sec\n", rr.getParams().getBenchmark(), speed);
     }
   }
 }

--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/JavaZipBench.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/JavaZipBench.java
@@ -33,7 +33,6 @@ package com.intel.qat.jmh;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -58,7 +57,8 @@ public class JavaZipBench {
   int compressedLength;
   int decompressedLength;
 
-  @Param({""}) String fileName;
+  @Param({""})
+  String fileName;
 
   @Setup
   public void prepare() {
@@ -83,8 +83,9 @@ public class JavaZipBench {
       inflater.reset();
 
       System.out.println("\n-------------------------");
-      System.out.printf("Compressed size: %d, ratio: %.2f\n", compressedLength,
-          (double) decompressedLength / compressedLength);
+      System.out.printf(
+          "Compressed size: %d, ratio: %.2f\n",
+          compressedLength, compressedLength * 100.0 / src.length);
       System.out.println("-------------------------");
     } catch (Exception e) {
       e.printStackTrace();

--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaBench.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaBench.java
@@ -35,10 +35,8 @@ import com.intel.qat.QatZipper;
 import com.intel.qat.QatZipper.Algorithm;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Collection;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
@@ -58,7 +56,8 @@ public class QatJavaBench {
   int compressedLength;
   int decompressedLength;
 
-  @Param({""}) String fileName;
+  @Param({""})
+  String fileName;
 
   @Setup
   public void prepare() {
@@ -78,8 +77,9 @@ public class QatJavaBench {
       decompressedLength = qzip.decompress(compressed, decompressed);
 
       System.out.println("\n-------------------------");
-      System.out.printf("Compressed size: %d, ratio: %.2f\n", compressedLength,
-          (double) decompressedLength / compressedLength);
+      System.out.printf(
+          "Compressed size: %d, ratio: %.2f\n",
+          compressedLength, compressedLength * 100.0 / src.length);
       System.out.println("-------------------------");
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/main/java/com/intel/qat/Native.java
+++ b/src/main/java/com/intel/qat/Native.java
@@ -21,15 +21,17 @@ class Native {
   static boolean isLoaded() {
     if (loaded) return true;
     try {
-      java.security.AccessController.doPrivileged(
-          new java.security.PrivilegedAction<Void>() {
-            public Void run() {
-              System.loadLibrary("qat-java"); // Could not load native library from
-              // "java.library.path", try loading from jar
+      SecurityManager sm = System.getSecurityManager();
+      if (sm == null) {
+        System.loadLibrary("qat-java");
+      } else {
+        java.security.PrivilegedAction<Void> pa =
+            () -> {
+              System.loadLibrary("qat-java");
               return null;
-            }
-          });
-
+            };
+        java.security.AccessController.doPrivileged(pa);
+      }
       loaded = true;
     } catch (UnsatisfiedLinkError e) {
       loaded = false;
@@ -88,13 +90,17 @@ class Native {
                 + " is a symbolic link.");
       }
       File finalTempNativeLib = tempNativeLib;
-      java.security.AccessController.doPrivileged(
-          new java.security.PrivilegedAction<Void>() {
-            public Void run() {
+      SecurityManager sm = System.getSecurityManager();
+      if (sm == null) {
+        System.load(finalTempNativeLib.getAbsolutePath());
+      } else {
+        java.security.PrivilegedAction<Void> pa =
+            () -> {
               System.load(finalTempNativeLib.getAbsolutePath());
               return null;
-            }
-          });
+            };
+        java.security.AccessController.doPrivileged(pa);
+      }
       loaded = true;
     } catch (IOException e) {
       throw new ExceptionInInitializerError(

--- a/src/main/jni/com_intel_qat_InternalJNI.c
+++ b/src/main/jni/com_intel_qat_InternalJNI.c
@@ -12,7 +12,7 @@
 #include "util.h"
 
 #define DEFLATE_ALGORITHM 0
-#define POLLING_MODE QZ_BUSY_POLLING
+#define POLLING_MODE QZ_PERIODICAL_POLLING
 
 /**
  * The fieldID for java.nio.ByteBuffer/position


### PR DESCRIPTION
- Changed polling mode from `QZ_BUSY_POLLING` to `QZ_PERIODIC_POLLING` due to a slow down with busy polling when bound to a single core.
- Improved JMH by having a fair comparison between java.util.zip and qat-zip. Also added spotless check.
- Modify `System.load` and `System.loadLibrary` such that a privilege execution is not required when there is no security manager.