### PR TITLE
Fix access control exception. Restore compression ratio calculation.

### DIFF
--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/JavaZipBench.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/JavaZipBench.java
@@ -88,7 +88,7 @@ public class JavaZipBench {
       System.out.println("\n-------------------------");
       System.out.printf(
           "Compressed size: %d, ratio: %.2f\n",
-          compressedLength, compressedLength * 100.0 / src.length);
+          compressedLength, src.length * 1.0 / compressedLength);
       System.out.println("-------------------------");
 
       // Close compressor and decompressor

--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaBench.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaBench.java
@@ -83,7 +83,7 @@ public class QatJavaBench {
       System.out.println("\n-------------------------");
       System.out.printf(
           "Compressed size: %d, ratio: %.2f\n",
-          compressedLength, compressedLength * 100.0 / src.length);
+          compressedLength, src.length * 1.0 / compressedLength);
       System.out.println("-------------------------");
 
       // Close QatZipper

--- a/src/main/java/com/intel/qat/QatZipper.java
+++ b/src/main/java/com/intel/qat/QatZipper.java
@@ -66,10 +66,24 @@ public class QatZipper {
   private int retryCount;
 
   /** Cleaner instance associated with this object. */
-  private static final Cleaner cleaner = Cleaner.create();
+  private static Cleaner cleaner;
 
   /** Cleaner.Cleanable instance representing QAT cleanup action. */
   private final Cleaner.Cleanable cleanable;
+
+  static {
+    SecurityManager sm = System.getSecurityManager();
+    if (sm == null) {
+      cleaner = Cleaner.create();
+    } else {
+      java.security.PrivilegedAction<Void> pa =
+          () -> {
+            cleaner = Cleaner.create();
+            return null;
+          };
+      java.security.AccessController.doPrivileged(pa);
+    }
+  }
 
   /** A reference to a QAT session in C. */
   long session;

--- a/src/main/jni/util.c
+++ b/src/main/jni/util.c
@@ -83,6 +83,6 @@ static char *get_error_msg(int err_code) {
 void throw_exception(JNIEnv *env, jlong err_code, const char *err_msg) {
   char buff[256];
   jclass Exception = (*env)->FindClass(env, "com/intel/qat/QatException");
-  snprintf(buff, sizeof(buff), "%s: %s", get_error_msg(err_code), err_msg);
+  snprintf(buff, sizeof(buff), "%s Error code returned was %s.", err_msg, get_error_msg(err_code));
   (*env)->ThrowNew(env, Exception, buff);
 }


### PR DESCRIPTION
- Fixes access control exception when executed in the context of a security manager.
- Restore compression ratio calculation as original length divided by compressed length.