### PR TITLE
Bytes consumed and written should be returned to user, even when an exception is thrown.

### DIFF
--- a/src/main/jni/com_intel_qat_InternalJNI.c
+++ b/src/main/jni/com_intel_qat_InternalJNI.c
@@ -95,13 +95,13 @@ static int compress(JNIEnv *env, QzSession_T *sess, unsigned char *src_ptr,
     }
   }
 
+  *bytes_read = src_len;
+  *bytes_written = dst_len;
+
   if (status != QZ_OK) {
     throw_exception(env, status, "Error occurred while compressing data.");
     return status;
   }
-
-  *bytes_read = src_len;
-  *bytes_written = dst_len;
 
   return QZ_OK;
 }
@@ -137,13 +137,14 @@ static int decompress(JNIEnv *env, QzSession_T *sess, unsigned char *src_ptr,
       retry_count--;
     }
   }
+
+  *bytes_read = src_len;
+  *bytes_written = dst_len;
+
   if (status != QZ_OK && status != QZ_BUF_ERROR && status != QZ_DATA_ERROR) {
     throw_exception(env, status, "Error occurred while decompressing data.");
     return status;
   }
-
-  *bytes_read = src_len;
-  *bytes_written = dst_len;
 
   return QZ_OK;
 }


### PR DESCRIPTION
During compression and decompression, the bytes consumed and written should be returned to user, even when an exception is thrown.