### PR TITLE
Performance Fix: Use Get/ReleasePrimitiveArrayCritical.

### DIFF
--- a/jmh/qat-java-bench/README.md
+++ b/jmh/qat-java-bench/README.md
@@ -1,5 +1,13 @@
-## Performance Test
-This JMH benchmark may be used to performance test the Qat-Java library.
+## JMH
+A set of JMH benchmarks.
+```
+Name              | Algorithm
+--------------------------------------------
+QatJavaBench      | DEFLATE, gzip-ext format
+JavaUtilZipBench  | DEFLATE, zlib format
+Lz4JavaBench      | LZ4
+ZstdJniBench      | Zstandard
+```
 
 ## Build
 To build the benchmark, execute the below command:
@@ -14,9 +22,9 @@ To run the benchmark, use the below command:
 java -jar target/benchmarks.jar [benchmark-class] -p file=/path/to/a/text-corpus -p level=<level> <jmh-params>
 ```
 
-For example:
+Example:
 ```
-java -jar target/benchmarks.jar QatZipBench -p file=silesia/dickens -p level=6 -bm thrpt -wi 1 -i 2 -t 1
+java -jar target/benchmarks.jar QatJavaBench -p file=silesia/dickens -p level=6 -wi 1 -i 2 -t 1
 ```
 
 You may get a text corpus for benchmarking from [Silesia compression corpus](https://sun.aei.polsl.pl//~sdeor/index.php?page=silesia). 

--- a/jmh/qat-java-bench/pom.xml
+++ b/jmh/qat-java-bench/pom.xml
@@ -62,6 +62,16 @@ THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>qat-java</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <version>1.5.5-10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.8.0</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/JavaUtilZipBench.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/JavaUtilZipBench.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD
+ ******************************************************************************/
+
+package com.intel.qat.jmh;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class JavaUtilZipBench {
+  private static AtomicBoolean flag = new AtomicBoolean(false);
+
+  @Param({""})
+  static String file;
+
+  @Param({"6"})
+  static int level;
+
+  @State(Scope.Thread)
+  public static class ThreadState {
+    byte[] src;
+    byte[] dst;
+    byte[] compressed;
+    byte[] decompressed;
+
+    public ThreadState() {
+      try {
+        // Create compressor and decompressor objects
+        Deflater deflater = new Deflater(level);
+        Inflater inflater = new Inflater();
+
+        // Read input
+        src = Files.readAllBytes(Paths.get(file));
+
+        decompressed = new byte[src.length];
+        dst = new byte[src.length];
+
+        // Compress input
+        deflater.setInput(src);
+        int compressedLength = deflater.deflate(dst);
+        deflater.end();
+
+        // Prepare compressed array of size EXACTLY compressedLength
+        compressed = new byte[compressedLength];
+        System.arraycopy(dst, 0, compressed, 0, compressedLength);
+
+        if (flag.compareAndSet(false, true)) {
+          System.out.println("\n------------------------");
+          System.out.printf("Compression ratio: %.2f%n", (double) src.length / compressed.length);
+          System.out.println("------------------------");
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  @Benchmark
+  public void compress(ThreadState state) {
+    Deflater deflater = new Deflater(level);
+    deflater.setInput(state.src);
+    deflater.deflate(state.dst);
+    deflater.end();
+  }
+
+  @Benchmark
+  public void decompress(ThreadState state) throws java.util.zip.DataFormatException {
+    Inflater inflater = new Inflater();
+    inflater.setInput(state.compressed);
+    inflater.inflate(state.decompressed);
+    inflater.end();
+  }
+}

--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaBench.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaBench.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD
+ ******************************************************************************/
+
+package com.intel.qat.jmh;
+
+import com.intel.qat.QatZipper;
+import com.intel.qat.QatZipper.Algorithm;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class QatJavaBench {
+  private static AtomicBoolean flag = new AtomicBoolean(false);
+
+  @Param({""})
+  static String file;
+
+  @Param({"6"})
+  static int level;
+
+  @State(Scope.Thread)
+  public static class ThreadState {
+    byte[] src;
+    byte[] dst;
+    byte[] compressed;
+    byte[] decompressed;
+
+    public ThreadState() {
+      try {
+        // Create compressor/decompressor object
+        QatZipper qzip = new QatZipper(Algorithm.DEFLATE, level);
+
+        // Read input
+        src = Files.readAllBytes(Paths.get(file));
+
+        decompressed = new byte[src.length];
+        dst = new byte[qzip.maxCompressedLength(src.length)];
+
+        // Compress input
+        int compressedLength = qzip.compress(src, dst);
+
+        // Prepare compressed array of size EXACTLY compressedLength
+        compressed = new byte[compressedLength];
+        System.arraycopy(dst, 0, compressed, 0, compressedLength);
+
+        // End session
+        qzip.end();
+
+        if (flag.compareAndSet(false, true)) {
+          System.out.println("\n------------------------");
+          System.out.printf("Compression ratio: %.2f%n", (double) src.length / compressed.length);
+          System.out.println("------------------------");
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  @Benchmark
+  public void compressWithDeflate(ThreadState state) {
+    QatZipper qzip = new QatZipper(Algorithm.DEFLATE, level);
+    qzip.compress(state.src, state.dst);
+    qzip.end();
+  }
+
+  @Benchmark
+  public void decompressWithDeflate(ThreadState state) {
+    QatZipper qzip = new QatZipper(Algorithm.DEFLATE, level);
+    qzip.decompress(state.compressed, state.decompressed);
+    qzip.end();
+  }
+}

--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaStreamBench.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaStreamBench.java
@@ -6,23 +6,24 @@
 
 package com.intel.qat.jmh;
 
+import static com.intel.qat.QatZipper.Algorithm;
+
+import com.intel.qat.QatCompressorOutputStream;
+import com.intel.qat.QatDecompressorInputStream;
+import com.intel.qat.QatZipper;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.zip.Deflater;
-import java.util.zip.DeflaterOutputStream;
-import java.util.zip.Inflater;
-import java.util.zip.InflaterInputStream;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
-public class JavaZipStreamBench {
+public class QatJavaStreamBench {
   private static final int BUFFER_SIZE = 1 << 16; // 64KB
   private static AtomicBoolean flag = new AtomicBoolean(false);
 
@@ -44,12 +45,13 @@ public class JavaZipStreamBench {
 
         // Compress input using streams
         ByteArrayOutputStream compressedOutput = new ByteArrayOutputStream();
-        Deflater deflater = new Deflater(level);
-        DeflaterOutputStream outputStream =
-            new DeflaterOutputStream(compressedOutput, deflater, BUFFER_SIZE);
-        outputStream.write(src, 0, src.length);
-        outputStream.close();
+        QatCompressorOutputStream qatOutputStream =
+            new QatCompressorOutputStream(
+                compressedOutput, BUFFER_SIZE, Algorithm.DEFLATE, level, QatZipper.Mode.HARDWARE);
+        qatOutputStream.write(src);
+        qatOutputStream.close();
 
+        // Get compressed data from stream
         compressed = compressedOutput.toByteArray();
 
         if (flag.compareAndSet(false, true)) {
@@ -66,22 +68,24 @@ public class JavaZipStreamBench {
   @Benchmark
   public void compress(ThreadState state) throws IOException {
     ByteArrayOutputStream compressedOutput = new ByteArrayOutputStream();
-    DeflaterOutputStream outputStream =
-        new DeflaterOutputStream(compressedOutput, new Deflater(level), BUFFER_SIZE);
-    outputStream.write(state.src, 0, state.src.length);
-    outputStream.close();
+    QatCompressorOutputStream qatOutputStream =
+        new QatCompressorOutputStream(
+            compressedOutput, BUFFER_SIZE, Algorithm.DEFLATE, level, QatZipper.Mode.HARDWARE);
+    qatOutputStream.write(state.src);
+    qatOutputStream.close();
   }
 
   @Benchmark
   public void decompress(ThreadState state) throws IOException {
     ByteArrayInputStream compressedInput = new ByteArrayInputStream(state.compressed);
-    InflaterInputStream inputStream =
-        new InflaterInputStream(compressedInput, new Inflater(), BUFFER_SIZE);
+    QatDecompressorInputStream qatInputStream =
+        new QatDecompressorInputStream(
+            compressedInput, BUFFER_SIZE, Algorithm.DEFLATE, QatZipper.Mode.HARDWARE);
 
     int bytesRead = 0;
     byte[] buffer = new byte[BUFFER_SIZE];
-    while ((bytesRead = inputStream.read(buffer)) != -1)
+    while ((bytesRead = qatInputStream.read(buffer)) != -1)
       ;
-    inputStream.close();
+    qatInputStream.close();
   }
 }

--- a/src/main/java/com/intel/qat/InternalJNI.java
+++ b/src/main/java/com/intel/qat/InternalJNI.java
@@ -17,7 +17,7 @@ class InternalJNI {
     Native.loadLibrary();
   }
 
-  static native void setup(QatZipper qzip, int mode, int codec, int level, int pmode);
+  static native void setup(QatZipper qzip, int algo, int level, int mode, int pmode);
 
   static native int maxCompressedSize(long session, long sourceSize);
 

--- a/src/main/java/com/intel/qat/QatZipper.java
+++ b/src/main/java/com/intel/qat/QatZipper.java
@@ -270,27 +270,14 @@ public class QatZipper {
    */
   public QatZipper(Algorithm algorithm, int level, Mode mode, int retryCount, PollingMode pmode)
       throws QatException {
-    if (!validateParams(algorithm, level, retryCount))
-      throw new IllegalArgumentException("Invalid compression level or retry count.");
+    if (retryCount < 0) throw new IllegalArgumentException("Invalid value for retry count.");
 
     this.retryCount = retryCount;
-    InternalJNI.setup(this, mode.ordinal(), algorithm.ordinal(), level, pmode.ordinal());
+    InternalJNI.setup(this, algorithm.ordinal(), level, mode.ordinal(), pmode.ordinal());
 
     // Register a QAT session cleaner for this object
     cleanable = cleaner.register(this, new QatCleaner(session));
     isValid = true;
-  }
-
-  /**
-   * Validates compression level and retry counts.
-   *
-   * @param algorithm the compression {@link algorithm}
-   * @param level the compression level.
-   * @param retryCount how many times to seek for a hardware resources before giving up.
-   * @return true if validation was successful, false otherwise.
-   */
-  private boolean validateParams(Algorithm algorithm, int level, int retryCount) {
-    return !(retryCount < 0 || level < 1 || level > 9);
   }
 
   /**

--- a/src/test/java/com/intel/qat/QatZipperTests.java
+++ b/src/test/java/com/intel/qat/QatZipperTests.java
@@ -320,9 +320,9 @@ public class QatZipperTests {
   @EnumSource(Algorithm.class)
   public void testInvalidCompressionLevel(Algorithm algo) {
     try {
-      qzip = new QatZipper(algo, 10);
+      qzip = new QatZipper(algo, 15);
       fail();
-    } catch (IllegalArgumentException e) {
+    } catch (QatException e) {
       assertTrue(true);
     }
   }


### PR DESCRIPTION
Replace the use of Get/ReleaseByteArrayElements with Get/ReleasePrimitiveArrayCritical. Get/ReleaseByteArrayElements appear to make a copy, substantially slowing down the performance of compression and decompression.