### PR TITLE
Fix bug with concurrent writes to field ids. Make BUSY polling default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Based on https://github.com/github/gitignore/blob/main/Java.gitignore and https://github.com/github/gitignore/blob/main/Maven.gitignore
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath

--- a/README.md
+++ b/README.md
@@ -41,11 +41,6 @@ To run all the unit tests, execute the below command.
 mvn clean test
 ```
 
-To include hardware specific tests, execute the below command:
-```
-mvn clean test -Dhardware.available=true
-```
-
 You can also install the [Jazzer](https://github.com/CodeIntelligenceTesting/jazzer/blob/main/CONTRIBUTING.md) tool and run Fuzz tests. 
 ```
 mvn clean test -Dfuzzing=true

--- a/jmh/qat-java-bench/README.md
+++ b/jmh/qat-java-bench/README.md
@@ -24,7 +24,7 @@ java -jar target/benchmarks.jar [benchmark-class] -p file=/path/to/a/text-corpus
 
 Example:
 ```
-java -jar target/benchmarks.jar QatJavaBench -p file=silesia/dickens -p level=6 -wi 1 -i 2 -t 1
+java -jar target/benchmarks.jar QatJavaBench -p file=silesia/dickens -p level=6 -f 1 -wi 1 -i 2 -t 1
 ```
 
 You may get a text corpus for benchmarking from [Silesia compression corpus](https://sun.aei.polsl.pl//~sdeor/index.php?page=silesia). 

--- a/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaStreamBench.java
+++ b/jmh/qat-java-bench/src/main/java/com/intel/qat/jmh/QatJavaStreamBench.java
@@ -47,7 +47,11 @@ public class QatJavaStreamBench {
         ByteArrayOutputStream compressedOutput = new ByteArrayOutputStream();
         QatCompressorOutputStream qatOutputStream =
             new QatCompressorOutputStream(
-                compressedOutput, BUFFER_SIZE, Algorithm.DEFLATE, level, QatZipper.Mode.HARDWARE);
+                compressedOutput,
+                BUFFER_SIZE,
+                Algorithm.DEFLATE,
+                level,
+                QatZipper.PollingMode.BUSY);
         qatOutputStream.write(src);
         qatOutputStream.close();
 
@@ -70,7 +74,7 @@ public class QatJavaStreamBench {
     ByteArrayOutputStream compressedOutput = new ByteArrayOutputStream();
     QatCompressorOutputStream qatOutputStream =
         new QatCompressorOutputStream(
-            compressedOutput, BUFFER_SIZE, Algorithm.DEFLATE, level, QatZipper.Mode.HARDWARE);
+            compressedOutput, BUFFER_SIZE, Algorithm.DEFLATE, level, QatZipper.PollingMode.BUSY);
     qatOutputStream.write(state.src);
     qatOutputStream.close();
   }
@@ -80,7 +84,7 @@ public class QatJavaStreamBench {
     ByteArrayInputStream compressedInput = new ByteArrayInputStream(state.compressed);
     QatDecompressorInputStream qatInputStream =
         new QatDecompressorInputStream(
-            compressedInput, BUFFER_SIZE, Algorithm.DEFLATE, QatZipper.Mode.HARDWARE);
+            compressedInput, BUFFER_SIZE, Algorithm.DEFLATE, QatZipper.PollingMode.BUSY);
 
     int bytesRead = 0;
     byte[] buffer = new byte[BUFFER_SIZE];

--- a/src/main/java/com/intel/qat/InternalJNI.java
+++ b/src/main/java/com/intel/qat/InternalJNI.java
@@ -17,6 +17,8 @@ class InternalJNI {
     Native.loadLibrary();
   }
 
+  static native void initFieldIDs();
+
   static native void setup(QatZipper qzip, int algo, int level, int mode, int pmode);
 
   static native int maxCompressedSize(long session, long sourceSize);

--- a/src/main/java/com/intel/qat/QatCompressorOutputStream.java
+++ b/src/main/java/com/intel/qat/QatCompressorOutputStream.java
@@ -8,6 +8,7 @@ package com.intel.qat;
 
 import static com.intel.qat.QatZipper.Algorithm;
 import static com.intel.qat.QatZipper.Mode;
+import static com.intel.qat.QatZipper.PollingMode;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
@@ -30,7 +31,8 @@ public class QatCompressorOutputStream extends FilterOutputStream {
 
   /**
    * Creates a new output stream with {@link DEFAULT_BUFFER_SIZE}, {@link Algorithm#DEFLATE}, {@link
-   * QatZipper#DEFAULT_COMPRESS_LEVEL}, and {@link Mode#HARDWARE}.
+   * QatZipper#DEFAULT_COMPRESS_LEVEL}, {@link QatZipper#DEFAULT_MODE}, and {@link
+   * PollingMode#BUSY}.
    *
    * @param out the output stream
    */
@@ -40,34 +42,86 @@ public class QatCompressorOutputStream extends FilterOutputStream {
         DEFAULT_BUFFER_SIZE,
         Algorithm.DEFLATE,
         QatZipper.DEFAULT_COMPRESS_LEVEL,
-        Mode.HARDWARE);
+        QatZipper.DEFAULT_MODE,
+        PollingMode.BUSY);
   }
 
   /**
    * Creates a new output stream with {@link Algorithm#DEFLATE}, {@link
-   * QatZipper#DEFAULT_COMPRESS_LEVEL}, and {@link Mode#HARDWARE}.
+   * QatZipper#DEFAULT_COMPRESS_LEVEL}, {@link QatZipper#DEFAULT_MODE}, and {@link
+   * PollingMode#BUSY}.
    *
    * @param out the output stream
    * @param bufferSize the output buffer size
    */
   public QatCompressorOutputStream(OutputStream out, int bufferSize) {
-    this(out, bufferSize, Algorithm.DEFLATE, QatZipper.DEFAULT_COMPRESS_LEVEL, Mode.HARDWARE);
+    this(
+        out,
+        bufferSize,
+        Algorithm.DEFLATE,
+        QatZipper.DEFAULT_COMPRESS_LEVEL,
+        QatZipper.DEFAULT_MODE,
+        PollingMode.BUSY);
   }
 
   /**
    * Creates a new output stream with given parameters, {@link QatZipper#DEFAULT_COMPRESS_LEVEL},
-   * and {@link Mode#HARDWARE}.
+   * {@link QatZipper#DEFAULT_MODE}, and {@link PollingMode#BUSY}.
    *
    * @param out the output stream
    * @param bufferSize the output buffer size
    * @param algorithm the compression algorithm (deflate or LZ4).
    */
   public QatCompressorOutputStream(OutputStream out, int bufferSize, Algorithm algorithm) {
-    this(out, bufferSize, algorithm, QatZipper.DEFAULT_COMPRESS_LEVEL, Mode.HARDWARE);
+    this(
+        out,
+        bufferSize,
+        algorithm,
+        QatZipper.DEFAULT_COMPRESS_LEVEL,
+        QatZipper.DEFAULT_MODE,
+        PollingMode.BUSY);
   }
 
   /**
-   * Creates a new output stream with the given parameters and {@link Mode#HARDWARE}.
+   * Creates a new output stream with given parameters, {@link Algorithm#DEFLATE}, {@link
+   * QatZipper#DEFAULT_COMPRESS_LEVEL}, and {@link PollingMode#BUSY}.
+   *
+   * @param out the output stream
+   * @param bufferSize the output buffer size
+   * @param mode the mode of operation (HARDWARE - only hardware, AUTO - hardware with a software
+   *     failover.)
+   */
+  public QatCompressorOutputStream(OutputStream out, int bufferSize, Mode mode) {
+    this(
+        out,
+        bufferSize,
+        Algorithm.DEFLATE,
+        QatZipper.DEFAULT_COMPRESS_LEVEL,
+        mode,
+        PollingMode.BUSY);
+  }
+
+  /**
+   * Creates a new output stream with given parameters, {@link Algorithm#DEFLATE}, {@link
+   * QatZipper#DEFAULT_COMPRESS_LEVEL}, and {@link PollingMode#BUSY}.
+   *
+   * @param out the output stream
+   * @param bufferSize the output buffer size
+   * @param pmode the polling mode
+   */
+  public QatCompressorOutputStream(OutputStream out, int bufferSize, PollingMode pmode) {
+    this(
+        out,
+        bufferSize,
+        Algorithm.DEFLATE,
+        QatZipper.DEFAULT_COMPRESS_LEVEL,
+        QatZipper.DEFAULT_MODE,
+        pmode);
+  }
+
+  /**
+   * Creates a new output stream with the given parameters, {@link QatZipper#DEFAULT_MODE}, and
+   * {@link PollingMode#BUSY}.
    *
    * @param out the output stream
    * @param bufferSize the output buffer size
@@ -76,12 +130,12 @@ public class QatCompressorOutputStream extends FilterOutputStream {
    */
   public QatCompressorOutputStream(
       OutputStream out, int bufferSize, Algorithm algorithm, int level) {
-    this(out, bufferSize, algorithm, level, Mode.HARDWARE);
+    this(out, bufferSize, algorithm, level, QatZipper.DEFAULT_MODE, PollingMode.BUSY);
   }
 
   /**
-   * Creates a new output stream with the given parameters and {@link
-   * QatZipper#DEFAULT_COMPRESS_LEVEL}.
+   * Creates a new output stream with the given parameters, {@link
+   * QatZipper#DEFAULT_COMPRESS_LEVEL}, and {@link PollingMode#BUSY}.
    *
    * @param out the output stream
    * @param bufferSize the output buffer size
@@ -91,11 +145,31 @@ public class QatCompressorOutputStream extends FilterOutputStream {
    */
   public QatCompressorOutputStream(
       OutputStream out, int bufferSize, Algorithm algorithm, Mode mode) {
-    this(out, bufferSize, algorithm, QatZipper.DEFAULT_COMPRESS_LEVEL, mode);
+    this(out, bufferSize, algorithm, QatZipper.DEFAULT_COMPRESS_LEVEL, mode, PollingMode.BUSY);
   }
 
   /**
-   * Creates a new output stream with the given paramters.
+   * Creates a new output stream with the given parameters, {@link
+   * QatZipper#DEFAULT_COMPRESS_LEVEL}, and {@link QatZipper#DEFAULT_MODE}.
+   *
+   * @param out the output stream
+   * @param bufferSize the output buffer size
+   * @param algorithm the compression algorithm (deflate or LZ4).
+   * @param pmode the polling mode
+   */
+  public QatCompressorOutputStream(
+      OutputStream out, int bufferSize, Algorithm algorithm, PollingMode pmode) {
+    this(
+        out,
+        bufferSize,
+        algorithm,
+        QatZipper.DEFAULT_COMPRESS_LEVEL,
+        QatZipper.DEFAULT_MODE,
+        pmode);
+  }
+
+  /**
+   * Creates a new output stream with the given parameters and {@link PollingMode#BUSY}.
    *
    * @param out the output stream
    * @param bufferSize the output buffer size
@@ -106,10 +180,44 @@ public class QatCompressorOutputStream extends FilterOutputStream {
    */
   public QatCompressorOutputStream(
       OutputStream out, int bufferSize, Algorithm algorithm, int level, Mode mode) {
+    this(out, bufferSize, algorithm, level, mode, PollingMode.BUSY);
+  }
+
+  /**
+   * Creates a new output stream with the given parameters and {@link QatZipper#DEFAULT_MODE}.
+   *
+   * @param out the output stream
+   * @param bufferSize the output buffer size
+   * @param algorithm the compression algorithm (deflate or LZ4).
+   * @param level the compression level.
+   * @param pmode the polling mode
+   */
+  public QatCompressorOutputStream(
+      OutputStream out, int bufferSize, Algorithm algorithm, int level, PollingMode pmode) {
+    this(out, bufferSize, algorithm, level, QatZipper.DEFAULT_MODE, pmode);
+  }
+
+  /**
+   * Creates a new output stream with the given paramters.
+   *
+   * @param out the output stream
+   * @param bufferSize the output buffer size
+   * @param algorithm the compression algorithm (deflate or LZ4).
+   * @param level the compression level.
+   * @param mode the mode of operation (HARDWARE - only hardware, AUTO - hardware with a software
+   * @param pmode the polling mode
+   */
+  public QatCompressorOutputStream(
+      OutputStream out,
+      int bufferSize,
+      Algorithm algorithm,
+      int level,
+      Mode mode,
+      PollingMode pmode) {
     super(out);
     if (bufferSize <= 0) throw new IllegalArgumentException();
     Objects.requireNonNull(out);
-    qzip = new QatZipper(algorithm, level, mode);
+    qzip = new QatZipper(algorithm, level, mode, pmode);
     inputBuffer = ByteBuffer.allocate(bufferSize);
     outputBuffer = ByteBuffer.allocate(qzip.maxCompressedLength(bufferSize));
     closed = false;

--- a/src/main/java/com/intel/qat/QatDecompressorInputStream.java
+++ b/src/main/java/com/intel/qat/QatDecompressorInputStream.java
@@ -8,6 +8,7 @@ package com.intel.qat;
 
 import static com.intel.qat.QatZipper.Algorithm;
 import static com.intel.qat.QatZipper.Mode;
+import static com.intel.qat.QatZipper.PollingMode;
 
 import java.io.FilterInputStream;
 import java.io.IOException;
@@ -30,38 +31,41 @@ public class QatDecompressorInputStream extends FilterInputStream {
   public static final int DEFAULT_BUFFER_SIZE = 1 << 16;
 
   /**
-   * Creates a new input stream with {@link DEFAULT_BUFFER_SIZE}, {@link Algorithm#DEFLATE}, and
-   * {@link Mode#HARDWARE}.
+   * Creates a new input stream with {@link DEFAULT_BUFFER_SIZE}, {@link Algorithm#DEFLATE}, {@link
+   * QatZipper#DEFAULT_MODE}, and {@link PollingMode#BUSY}.
    *
    * @param in the input stream
    */
   public QatDecompressorInputStream(InputStream in) {
-    this(in, DEFAULT_BUFFER_SIZE, Algorithm.DEFLATE, Mode.HARDWARE);
+    this(in, DEFAULT_BUFFER_SIZE, Algorithm.DEFLATE, QatZipper.DEFAULT_MODE, PollingMode.BUSY);
   }
 
   /**
-   * Creates a new input stream with {@link Algorithm#DEFLATE}, and {@link Mode#HARDWARE}.
+   * Creates a new input stream with {@link Algorithm#DEFLATE}, {@link QatZipper#DEFAULT_MODE}, and
+   * {@link PollingMode#BUSY}.
    *
    * @param in the input stream
    * @param bufferSize the input buffer size
    */
   public QatDecompressorInputStream(InputStream in, int bufferSize) {
-    this(in, bufferSize, Algorithm.DEFLATE, Mode.HARDWARE);
+    this(in, bufferSize, Algorithm.DEFLATE, QatZipper.DEFAULT_MODE, PollingMode.BUSY);
   }
 
   /**
-   * Creates a new input stream with the given algorithm, and {@link Mode#HARDWARE}.
+   * Creates a new input stream with the given parameters, {@link QatZipper#DEFAULT_MODE}, and
+   * {@link PollingMode#BUSY}.
    *
    * @param in the input stream
    * @param bufferSize the input buffer size
    * @param algorithm the compression algorithm (deflate or LZ4).
    */
   public QatDecompressorInputStream(InputStream in, int bufferSize, Algorithm algorithm) {
-    this(in, bufferSize, algorithm, Mode.HARDWARE);
+    this(in, bufferSize, algorithm, QatZipper.DEFAULT_MODE, PollingMode.BUSY);
   }
 
   /**
-   * Creates a new input stream with the given mode, and {@link Algorithm#DEFLATE}.
+   * Creates a new input stream with the given mode, {@link Algorithm#DEFLATE}, and {@link
+   * PollingMode#BUSY}.
    *
    * @param in the input stream
    * @param bufferSize the input buffer size
@@ -69,7 +73,46 @@ public class QatDecompressorInputStream extends FilterInputStream {
    *     failover.)
    */
   public QatDecompressorInputStream(InputStream in, int bufferSize, Mode mode) {
-    this(in, bufferSize, Algorithm.DEFLATE, mode);
+    this(in, bufferSize, Algorithm.DEFLATE, mode, PollingMode.BUSY);
+  }
+
+  /**
+   * Creates a new input stream with the given polling mode, {@link Algorithm#DEFLATE} and {@link
+   * QatZipper#DEFAULT_MODE}.
+   *
+   * @param in the input stream
+   * @param bufferSize the input buffer size
+   * @param pmode the polling mode
+   */
+  public QatDecompressorInputStream(InputStream in, int bufferSize, PollingMode pmode) {
+    this(in, bufferSize, Algorithm.DEFLATE, QatZipper.DEFAULT_MODE, pmode);
+  }
+
+  /**
+   * Creates a new input stream with the given parameters and {@link PollingMode#BUSY}.
+   *
+   * @param in the input stream
+   * @param bufferSize the input buffer size
+   * @param algorithm the compression algorithm (deflate or LZ4).
+   * @param mode the mode of operation (HARDWARE - only hardware, AUTO - hardware with a software
+   *     failover.)
+   */
+  public QatDecompressorInputStream(
+      InputStream in, int bufferSize, Algorithm algorithm, Mode mode) {
+    this(in, bufferSize, algorithm, mode, PollingMode.BUSY);
+  }
+
+  /**
+   * Creates a new input stream with the given parameters and {@link QatZipper#DEFAULT_MODE}.
+   *
+   * @param in the input stream
+   * @param bufferSize the input buffer size
+   * @param algorithm the compression algorithm (deflate or LZ4).
+   * @param pmode the polling mode
+   */
+  public QatDecompressorInputStream(
+      InputStream in, int bufferSize, Algorithm algorithm, PollingMode pmode) {
+    this(in, bufferSize, algorithm, QatZipper.DEFAULT_MODE, pmode);
   }
 
   /**
@@ -80,16 +123,17 @@ public class QatDecompressorInputStream extends FilterInputStream {
    * @param algorithm the compression algorithm (deflate or LZ4).
    * @param mode the mode of operation (HARDWARE - only hardware, AUTO - hardware with a software
    *     failover.)
+   * @param pmode the polling mode
    */
   public QatDecompressorInputStream(
-      InputStream in, int bufferSize, Algorithm algorithm, Mode mode) {
+      InputStream in, int bufferSize, Algorithm algorithm, Mode mode, PollingMode pmode) {
     super(in);
     if (bufferSize <= 0) throw new IllegalArgumentException();
     Objects.requireNonNull(in);
     inputBuffer = ByteBuffer.allocate(bufferSize);
     outputBuffer = ByteBuffer.allocate(bufferSize);
     outputBuffer.position(outputBuffer.capacity());
-    qzip = new QatZipper(algorithm, mode);
+    qzip = new QatZipper(algorithm, mode, pmode);
     closed = false;
     eof = false;
   }

--- a/src/main/java/com/intel/qat/QatZipper.java
+++ b/src/main/java/com/intel/qat/QatZipper.java
@@ -66,7 +66,7 @@ public class QatZipper {
   public static final Mode DEFAULT_MODE = Mode.HARDWARE;
 
   /** The default polling mode. */
-  public static final PollingMode DEFAULT_POLLING_MODE = PollingMode.PERIODICAL;
+  public static final PollingMode DEFAULT_POLLING_MODE = PollingMode.BUSY;
 
   private boolean isValid;
 
@@ -90,6 +90,8 @@ public class QatZipper {
   private final Cleaner.Cleanable cleanable;
 
   static {
+    InternalJNI.initFieldIDs();
+
     SecurityManager sm = System.getSecurityManager();
     if (sm == null) {
       cleaner = Cleaner.create();
@@ -118,13 +120,36 @@ public class QatZipper {
     AUTO;
   }
 
-  /** The polling mode to use. PERIODICAL and BUSY are supported. */
+  /**
+   * Polling mode dictates how QAT processes compression/decompression requests and waits for a
+   * response, directly affecting the performance of these operations. Two polling modes are
+   * supported: BUSY and PERIODICAL. <br>
+   * <br>
+   * Use BUSY polling mode when:
+   *
+   * <ul>
+   *   <li>Your CPUs are not fully saturated and have cycles to spare.
+   *   <li>Your workload is latency sensitive
+   * </ul>
+   *
+   * <br>
+   * Use PERIODICAL polling mode when:
+   *
+   * <ul>
+   *   <li>Your workload has very high CPU utilization.
+   *   <li>Your workload is throughput sensitive.
+   * </ul>
+   *
+   * In cases where you are not able to make a determination, considering checking both modes.
+   */
   public static enum PollingMode {
-    /** The default polling mode. Preferred mode for throughput sensitive uses cases. */
-    PERIODICAL,
+    /**
+     * Use when (i) your CPUS are not fully saturated, or (ii) your workload is latency sensitive.
+     */
+    BUSY,
 
-    /** BUSY polling. Preferred for latency sensitive use cases. */
-    BUSY
+    /** Use when (i) your workload is CPU bound, or (ii) your work is throghput sensitive. */
+    PERIODICAL
   }
 
   /** The compression algorithm to use. DEFLATE and LZ4 are supported. */

--- a/src/main/java/com/intel/qat/QatZipper.java
+++ b/src/main/java/com/intel/qat/QatZipper.java
@@ -62,6 +62,12 @@ public class QatZipper {
    */
   public static final int DEFAULT_RETRY_COUNT = 0;
 
+  /** The default execution mode. */
+  public static final Mode DEFAULT_MODE = Mode.HARDWARE;
+
+  /** The default polling mode. */
+  public static final PollingMode DEFAULT_POLLING_MODE = PollingMode.PERIODICAL;
+
   private boolean isValid;
 
   private int retryCount;
@@ -132,31 +138,27 @@ public class QatZipper {
 
   /**
    * Creates a new QatZipper that uses {@link Algorithm#DEFLATE}, {@link DEFAULT_COMPRESS_LEVEL},
-   * {@link Mode#HARDWARE}, {@link DEFAULT_RETRY_COUNT}, and {@link PollingMode#PERIODICAL}.
+   * {@link DEFAULT_MODE}, {@link DEFAULT_RETRY_COUNT}, and {@link DEFAULT_POLLING_MODE}.
    */
   public QatZipper() {
     this(
         Algorithm.DEFLATE,
         DEFAULT_COMPRESS_LEVEL,
-        Mode.HARDWARE,
+        DEFAULT_MODE,
         DEFAULT_RETRY_COUNT,
-        PollingMode.PERIODICAL);
+        DEFAULT_POLLING_MODE);
   }
 
   /**
    * Creates a new QatZipper with the specified execution {@link Mode}. Uses {@link
    * Algorithm#DEFLATE}, {@link DEFAULT_COMPRESS_LEVEL}, {@link DEFAULT_RETRY_COUNT}, and {@link
-   * PollingMode#PERIODICAL}.
+   * DEFAULT_POLLING_MODE}.
    *
    * @param mode the {@link Mode} of QAT execution
    */
   public QatZipper(Mode mode) {
     this(
-        Algorithm.DEFLATE,
-        DEFAULT_COMPRESS_LEVEL,
-        mode,
-        DEFAULT_RETRY_COUNT,
-        PollingMode.PERIODICAL);
+        Algorithm.DEFLATE, DEFAULT_COMPRESS_LEVEL, mode, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
   }
 
   /**
@@ -166,63 +168,71 @@ public class QatZipper {
    * @param pmode the {@link PollingMode}
    */
   public QatZipper(PollingMode pmode) {
-    this(Algorithm.DEFLATE, DEFAULT_COMPRESS_LEVEL, Mode.HARDWARE, DEFAULT_RETRY_COUNT, pmode);
+    this(Algorithm.DEFLATE, DEFAULT_COMPRESS_LEVEL, DEFAULT_MODE, DEFAULT_RETRY_COUNT, pmode);
   }
 
   /**
    * Creates a new QatZipper with the specified compression {@link Algorithm}. Uses {@link
-   * DEFAULT_COMPRESS_LEVEL}, {@link Mode#HARDWARE}, {@link DEFAULT_RETRY_COUNT}, and {@link
-   * PollingMode#PERIODICAL}.
+   * DEFAULT_COMPRESS_LEVEL}, {@link DEFAULT_MODE}, {@link DEFAULT_RETRY_COUNT}, and {@link
+   * DEFAULT_POLLING_MODE}.
    *
    * @param algorithm the compression {@link Algorithm}
    */
   public QatZipper(Algorithm algorithm) {
     this(
-        algorithm,
-        DEFAULT_COMPRESS_LEVEL,
-        Mode.HARDWARE,
-        DEFAULT_RETRY_COUNT,
-        PollingMode.PERIODICAL);
+        algorithm, DEFAULT_COMPRESS_LEVEL, DEFAULT_MODE, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
   }
 
   /**
    * Creates a new QatZipper with the specified {@link Algorithm} and {@link Mode} of execution.
    * Uses {@link DEFAULT_COMPRESS_LEVEL}, {@link DEFAULT_RETRY_COUNT}, and {@link
-   * PollingMode#PERIODICAL}.
+   * DEFAULT_POLLING_MODE}.
    *
    * @param algorithm the compression {@link Algorithm}
    * @param mode the {@link Mode} of QAT execution
    */
   public QatZipper(Algorithm algorithm, Mode mode) {
-    this(algorithm, DEFAULT_COMPRESS_LEVEL, mode, DEFAULT_RETRY_COUNT, PollingMode.PERIODICAL);
+    this(algorithm, DEFAULT_COMPRESS_LEVEL, mode, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
   }
 
   /**
    * Creates a new QatZipper with the specified {@link Algorithm} and {@link PollingMode} of
-   * execution. Uses {@link DEFAULT_COMPRESS_LEVEL}, {@link Mode#HARDWARE}, and {@link
+   * execution. Uses {@link DEFAULT_COMPRESS_LEVEL}, {@link DEFAULT_MODE}, and {@link
    * DEFAULT_RETRY_COUNT}
    *
    * @param algorithm the compression {@link Algorithm}
    * @param pmode the {@link PollingMode}
    */
   public QatZipper(Algorithm algorithm, PollingMode pmode) {
-    this(algorithm, DEFAULT_COMPRESS_LEVEL, Mode.HARDWARE, DEFAULT_RETRY_COUNT, pmode);
+    this(algorithm, DEFAULT_COMPRESS_LEVEL, DEFAULT_MODE, DEFAULT_RETRY_COUNT, pmode);
+  }
+
+  /**
+   * Creates a new QatZipper with the specified {@link Algorithm} and {@link Mode} of execution.
+   * Uses {@link DEFAULT_COMPRESS_LEVEL} and {@link DEFAULT_RETRY_COUNT}.
+   *
+   * @param algorithm the compression {@link Algorithm}
+   * @param mode the {@link Mode} of QAT execution
+   * @param pmode the {@link PollingMode}
+   */
+  public QatZipper(Algorithm algorithm, Mode mode, PollingMode pmode) {
+    this(algorithm, DEFAULT_COMPRESS_LEVEL, mode, DEFAULT_RETRY_COUNT, pmode);
   }
 
   /**
    * Creates a new QatZipper with the specified {@link Algorithm} and compression level. Uses {@link
-   * Mode#HARDWARE}, {@link DEFAULT_RETRY_COUNT}, and {@link PollingMode#PERIODICAL}.
+   * DEFAULT_MODE}, {@link DEFAULT_RETRY_COUNT}, and {@link DEFAULT_POLLING_MODE}.
    *
    * @param algorithm the compression algorithm (deflate or LZ4).
    * @param level the compression level.
    */
   public QatZipper(Algorithm algorithm, int level) {
-    this(algorithm, level, Mode.HARDWARE, DEFAULT_RETRY_COUNT, PollingMode.PERIODICAL);
+    this(algorithm, level, DEFAULT_MODE, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
   }
 
   /**
    * Creates a new QatZipper with the specified {@link Algorithm}, compression level, and {@link
-   * Mode}. Uses {@link DEFAULT_RETRY_COUNT} and {@link PollingMode#PERIODICAL}.
+   * Mode}. Uses {@link DEFAULT_RETRY_COUNT} and {@link DEFAULT_POLLING_MODE}.
    *
    * @param algorithm the compression algorithm (deflate or LZ4).
    * @param level the compression level.
@@ -230,23 +240,23 @@ public class QatZipper {
    *     failover.)
    */
   public QatZipper(Algorithm algorithm, int level, Mode mode) {
-    this(algorithm, level, mode, DEFAULT_RETRY_COUNT, PollingMode.PERIODICAL);
+    this(algorithm, level, mode, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
   }
 
   /**
    * Creates a new QatZipper with the specified {@link Algorithm}, compression level, and {@link
-   * PollingMode}. Uses {@link Mode#HARDWARE} and {@link DEFAULT_RETRY_COUNT}.
+   * PollingMode}. Uses {@link DEFAULT_MODE} and {@link DEFAULT_RETRY_COUNT}.
    *
    * @param algorithm the compression algorithm (deflate or LZ4).
    * @param level the compression level.
    * @param pmode the {@link PollingMode}
    */
   public QatZipper(Algorithm algorithm, int level, PollingMode pmode) {
-    this(algorithm, level, Mode.HARDWARE, DEFAULT_RETRY_COUNT, pmode);
+    this(algorithm, level, DEFAULT_MODE, DEFAULT_RETRY_COUNT, pmode);
   }
 
   /**
-   * Creates a new QatZipper with the specified parameters and {@link PollingMode#PERIODICAL}.
+   * Creates a new QatZipper with the specified parameters and {@link DEFAULT_POLLING_MODE}.
    *
    * @param algorithm the compression {@link Algorithm}
    * @param level the compression level.
@@ -255,7 +265,20 @@ public class QatZipper {
    * @throws QatException if QAT session cannot be created.
    */
   public QatZipper(Algorithm algorithm, int level, Mode mode, int retryCount) {
-    this(algorithm, level, mode, retryCount, PollingMode.PERIODICAL);
+    this(algorithm, level, mode, retryCount, DEFAULT_POLLING_MODE);
+  }
+
+  /**
+   * Creates a new QatZipper with the specified parameters and {@link DEFAULT_RETRY_COUNT}.
+   *
+   * @param algorithm the compression {@link Algorithm}
+   * @param level the compression level.
+   * @param mode the {@link Mode} of QAT execution
+   * @param pmode the {@link PollingMode}
+   * @throws QatException if QAT session cannot be created.
+   */
+  public QatZipper(Algorithm algorithm, int level, Mode mode, PollingMode pmode) {
+    this(algorithm, level, mode, DEFAULT_RETRY_COUNT, pmode);
   }
 
   /**

--- a/src/main/java/com/intel/qat/QatZipper.java
+++ b/src/main/java/com/intel/qat/QatZipper.java
@@ -68,8 +68,12 @@ public class QatZipper {
   /** The default polling mode. */
   public static final PollingMode DEFAULT_POLLING_MODE = PollingMode.BUSY;
 
+  /** Indicates if a QAT session is valid or not. */
   private boolean isValid;
 
+  /**
+   * The number of retry counts for session creation before Qat-Java gives up and throws an error.
+   */
   private int retryCount;
 
   /** Number of bytes read from the source by the most recent call to a compress/decompress. */
@@ -92,6 +96,7 @@ public class QatZipper {
   static {
     InternalJNI.initFieldIDs();
 
+    // Needed for applications where a Java security manager is in place -- e.g. OpenSearch.
     SecurityManager sm = System.getSecurityManager();
     if (sm == null) {
       cleaner = Cleaner.create();
@@ -123,13 +128,13 @@ public class QatZipper {
   /**
    * Polling mode dictates how QAT processes compression/decompression requests and waits for a
    * response, directly affecting the performance of these operations. Two polling modes are
-   * supported: BUSY and PERIODICAL. <br>
+   * supported: BUSY and PERIODICAL. BUSY polling is the default polling mode.<br>
    * <br>
    * Use BUSY polling mode when:
    *
    * <ul>
    *   <li>Your CPUs are not fully saturated and have cycles to spare.
-   *   <li>Your workload is latency sensitive
+   *   <li>Your workload is latency-sensitive.
    * </ul>
    *
    * <br>
@@ -137,18 +142,14 @@ public class QatZipper {
    *
    * <ul>
    *   <li>Your workload has very high CPU utilization.
-   *   <li>Your workload is throughput sensitive.
+   *   <li>Your workload is throughput-sensitive.
    * </ul>
-   *
-   * In cases where you are not able to make a determination, considering checking both modes.
    */
   public static enum PollingMode {
-    /**
-     * Use when (i) your CPUS are not fully saturated, or (ii) your workload is latency sensitive.
-     */
+    /** Use this mode unless your workload is CPU-bound. */
     BUSY,
 
-    /** Use when (i) your workload is CPU bound, or (ii) your work is throghput sensitive. */
+    /** Use this mode when your workload is CPU-bound. */
     PERIODICAL
   }
 
@@ -175,6 +176,18 @@ public class QatZipper {
   }
 
   /**
+   * Creates a new QatZipper with the specified compression {@link Algorithm}. Uses {@link
+   * DEFAULT_COMPRESS_LEVEL}, {@link DEFAULT_MODE}, {@link DEFAULT_RETRY_COUNT}, and {@link
+   * DEFAULT_POLLING_MODE}.
+   *
+   * @param algorithm the compression {@link Algorithm}
+   */
+  public QatZipper(Algorithm algorithm) {
+    this(
+        algorithm, DEFAULT_COMPRESS_LEVEL, DEFAULT_MODE, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
+  }
+
+  /**
    * Creates a new QatZipper with the specified execution {@link Mode}. Uses {@link
    * Algorithm#DEFLATE}, {@link DEFAULT_COMPRESS_LEVEL}, {@link DEFAULT_RETRY_COUNT}, and {@link
    * DEFAULT_POLLING_MODE}.
@@ -197,15 +210,14 @@ public class QatZipper {
   }
 
   /**
-   * Creates a new QatZipper with the specified compression {@link Algorithm}. Uses {@link
-   * DEFAULT_COMPRESS_LEVEL}, {@link DEFAULT_MODE}, {@link DEFAULT_RETRY_COUNT}, and {@link
-   * DEFAULT_POLLING_MODE}.
+   * Creates a new QatZipper with the specified {@link Algorithm} and compression level. Uses {@link
+   * DEFAULT_MODE}, {@link DEFAULT_RETRY_COUNT}, and {@link DEFAULT_POLLING_MODE}.
    *
-   * @param algorithm the compression {@link Algorithm}
+   * @param algorithm the compression algorithm (deflate or LZ4).
+   * @param level the compression level.
    */
-  public QatZipper(Algorithm algorithm) {
-    this(
-        algorithm, DEFAULT_COMPRESS_LEVEL, DEFAULT_MODE, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
+  public QatZipper(Algorithm algorithm, int level) {
+    this(algorithm, level, DEFAULT_MODE, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
   }
 
   /**
@@ -242,17 +254,6 @@ public class QatZipper {
    */
   public QatZipper(Algorithm algorithm, Mode mode, PollingMode pmode) {
     this(algorithm, DEFAULT_COMPRESS_LEVEL, mode, DEFAULT_RETRY_COUNT, pmode);
-  }
-
-  /**
-   * Creates a new QatZipper with the specified {@link Algorithm} and compression level. Uses {@link
-   * DEFAULT_MODE}, {@link DEFAULT_RETRY_COUNT}, and {@link DEFAULT_POLLING_MODE}.
-   *
-   * @param algorithm the compression algorithm (deflate or LZ4).
-   * @param level the compression level.
-   */
-  public QatZipper(Algorithm algorithm, int level) {
-    this(algorithm, level, DEFAULT_MODE, DEFAULT_RETRY_COUNT, DEFAULT_POLLING_MODE);
   }
 
   /**

--- a/src/main/jni/com_intel_qat_InternalJNI.c
+++ b/src/main/jni/com_intel_qat_InternalJNI.c
@@ -37,7 +37,7 @@ static jfieldID nio_bytebuffer_position_id;
 static jfieldID qzip_bytes_read_id;
 
 /**
- * Setups a QAT session for DEFLATE.
+ * Sets up a QAT session for DEFLATE.
  *
  * @param qz_session a pointer to the QzSession_T.
  * @param level the compression level to use.
@@ -59,7 +59,7 @@ static int setup_deflate_session(QzSession_T *qz_session, int level,
 }
 
 /**
- * Setups a QAT session for LZ4.
+ * Sets up a QAT session for LZ4.
  *
  * @param qz_session a pointer to the QzSession_T.
  * @param level the compression level to use.
@@ -178,11 +178,27 @@ static int decompress(JNIEnv *env, QzSession_T *sess, unsigned char *src_ptr,
 }
 
 /*
- * Setups a QAT session.
+ * Class:     com_intel_qat_InternalJNI
+ * Method:    initFieldIDs
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_intel_qat_InternalJNI_initFieldIDs(JNIEnv *env,
+                                                                   jclass clz) {
+  (void)clz;
+
+  nio_bytebuffer_position_id = (*env)->GetFieldID(
+      env, (*env)->FindClass(env, "java/nio/ByteBuffer"), "position", "I");
+
+  qzip_bytes_read_id = (*env)->GetFieldID(
+      env, (*env)->FindClass(env, "com/intel/qat/QatZipper"), "bytesRead", "I");
+}
+
+/*
+ * Sets up a QAT session.
  *
  * Class:     com_intel_qat_InternalJNI
  * Method:    setup
- * Signature: (Lcom/intel/qat/QatZipper;IJII)V
+ * Signature: (Lcom/intel/qat/QatZipper;IIII)V
  */
 JNIEXPORT void JNICALL Java_com_intel_qat_InternalJNI_setup(
     JNIEnv *env, jclass clz, jobject qat_zipper, jint comp_algorithm,
@@ -193,13 +209,6 @@ JNIEXPORT void JNICALL Java_com_intel_qat_InternalJNI_setup(
     throw_exception(env, QZ_PARAMS, "Invalid compression level given.");
     return;
   }
-
-  // save the fieldID of nio.ByteBuffer.position
-  nio_bytebuffer_position_id = (*env)->GetFieldID(
-      env, (*env)->FindClass(env, "java/nio/ByteBuffer"), "position", "I");
-
-  qzip_bytes_read_id = (*env)->GetFieldID(
-      env, (*env)->FindClass(env, "com/intel/qat/QatZipper"), "bytesRead", "I");
 
   QzSession_T *qz_session = (QzSession_T *)calloc(1, sizeof(QzSession_T));
 
@@ -232,7 +241,7 @@ JNIEXPORT void JNICALL Java_com_intel_qat_InternalJNI_setup(
  *
  * Class:     com_intel_qat_InternalJNI
  * Method:    compressByteArray
- * Signature: (J[BII[BIII)I
+ * Signature: (Lcom/intel/qat/QatZipper;J[BII[BIII)I
  */
 JNIEXPORT jint JNICALL Java_com_intel_qat_InternalJNI_compressByteArray(
     JNIEnv *env, jclass clz, jobject qat_zipper, jlong sess, jbyteArray src_arr,
@@ -267,7 +276,7 @@ JNIEXPORT jint JNICALL Java_com_intel_qat_InternalJNI_compressByteArray(
  *
  * Class:     com_intel_qat_InternalJNI
  * Method:    decompressByteArray
- * Signature: (J[BII[BIII)I
+ * Signature: (Lcom/intel/qat/QatZipper;J[BII[BIII)I
  */
 JNIEXPORT jint JNICALL Java_com_intel_qat_InternalJNI_decompressByteArray(
     JNIEnv *env, jclass clz, jobject qat_zipper, jlong sess, jbyteArray src_arr,
@@ -501,7 +510,7 @@ Java_com_intel_qat_InternalJNI_decompressDirectByteBufferSrc(
 /*
  * Class:     com_intel_qat_InternalJNI
  * Method:    compressDirectByteBufferDst
- * Signature: (J[BIILjava/nio/ByteBuffer;III)I
+ * Signature: (JLjava/nio/ByteBuffer;[BIILjava/nio/ByteBuffer;III)I
  */
 JNIEXPORT jint JNICALL
 Java_com_intel_qat_InternalJNI_compressDirectByteBufferDst(
@@ -531,6 +540,7 @@ Java_com_intel_qat_InternalJNI_compressDirectByteBufferDst(
 
   return bytes_written;
 }
+
 /*
  * Class:     com_intel_qat_InternalJNI
  * Method:    decompressDirectByteBufferDst
@@ -581,7 +591,7 @@ JNIEXPORT jint JNICALL Java_com_intel_qat_InternalJNI_maxCompressedSize(
 }
 
 /*
- * Tearsdown the given QAT session.
+ * Tear downs the given QAT session.
  *
  * Class:     com_intel_qat_InternalJNI
  * Method:    teardown

--- a/src/main/jni/com_intel_qat_InternalJNI.h
+++ b/src/main/jni/com_intel_qat_InternalJNI.h
@@ -9,20 +9,20 @@ extern "C" {
 #endif
 /*
  * Class:     com_intel_qat_InternalJNI
+ * Method:    initFieldIDs
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_intel_qat_InternalJNI_initFieldIDs(JNIEnv *,
+                                                                   jclass);
+
+/*
+ * Class:     com_intel_qat_InternalJNI
  * Method:    setup
- * Signature: (Lcom/intel/qat/QatZipper;IJIII)V
+ * Signature: (Lcom/intel/qat/QatZipper;IIII)V
  */
 JNIEXPORT void JNICALL Java_com_intel_qat_InternalJNI_setup(JNIEnv *, jclass,
                                                             jobject, jint, jint,
                                                             jint, jint);
-
-/*
- * Class:     com_intel_qat_InternalJNI
- * Method:    teardown
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_intel_qat_InternalJNI_teardown(JNIEnv *, jclass,
-                                                               jlong);
 
 /*
  * Class:     com_intel_qat_InternalJNI
@@ -110,7 +110,7 @@ Java_com_intel_qat_InternalJNI_decompressDirectByteBufferSrc(
 /*
  * Class:     com_intel_qat_InternalJNI
  * Method:    compressDirectByteBufferDst
- * Signature: (J[BIILjava/nio/ByteBuffer;III)I
+ * Signature: (JLjava/nio/ByteBuffer;[BIILjava/nio/ByteBuffer;III)I
  */
 JNIEXPORT jint JNICALL
 Java_com_intel_qat_InternalJNI_compressDirectByteBufferDst(JNIEnv *, jclass,
@@ -122,7 +122,7 @@ Java_com_intel_qat_InternalJNI_compressDirectByteBufferDst(JNIEnv *, jclass,
 /*
  * Class:     com_intel_qat_InternalJNI
  * Method:    decompressDirectByteBufferDst
- * Signature: (J[BIILjava/nio/ByteBuffer;III)I
+ * Signature: (JLjava/nio/ByteBuffer;[BIILjava/nio/ByteBuffer;III)I
  */
 JNIEXPORT jint JNICALL
 Java_com_intel_qat_InternalJNI_decompressDirectByteBufferDst(JNIEnv *, jclass,
@@ -130,6 +130,15 @@ Java_com_intel_qat_InternalJNI_decompressDirectByteBufferDst(JNIEnv *, jclass,
                                                              jbyteArray, jint,
                                                              jint, jobject,
                                                              jint, jint, jint);
+
+/*
+ * Class:     com_intel_qat_InternalJNI
+ * Method:    teardown
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_intel_qat_InternalJNI_teardown(JNIEnv *, jclass,
+                                                               jlong);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
1. Makes BUSY polling the default polling mode.
2. Fixes a torn-writes issue with field IDs.
3. Improve Java Doc documentation.